### PR TITLE
Revert "Backpressure."

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -126,40 +126,33 @@ async fn sync(
     let target_dir = Arc::from(provider.target_dir.clone().into_boxed_path());
     if provider.scrape_info {
         debug!("Scraping info");
-        handle
-            .enqueue(
-                tl_scraper::sync_info(tl.clone(), Arc::clone(&target_dir))
-                    .instrument(Span::current()),
-            )
-            .await?;
+        handle.spawn(
+            tl_scraper::sync_info(tl.clone(), Arc::clone(&target_dir)).instrument(Span::current()),
+        )?;
     }
     if provider.scrape_accounts {
         debug!("Scraping accounts");
-        handle
-            .enqueue(
-                tl_scraper::sync_accounts(
-                    tl.clone(),
-                    target_dir.clone(),
-                    from_date..=to_date,
-                    handle.clone(),
-                )
-                .instrument(Span::current()),
+        handle.spawn(
+            tl_scraper::sync_accounts(
+                tl.clone(),
+                target_dir.clone(),
+                from_date..=to_date,
+                handle.clone(),
             )
-            .await?;
+            .instrument(Span::current()),
+        )?;
     }
     if provider.scrape_cards {
         debug!("Scraping cards");
-        handle
-            .enqueue(
-                tl_scraper::sync_cards(
-                    tl.clone(),
-                    target_dir.clone(),
-                    from_date..=to_date,
-                    handle.clone(),
-                )
-                .instrument(Span::current()),
+        handle.spawn(
+            tl_scraper::sync_cards(
+                tl.clone(),
+                target_dir.clone(),
+                from_date..=to_date,
+                handle.clone(),
             )
-            .await?;
+            .instrument(Span::current()),
+        )?;
     }
     drop(handle);
     debug!("Scheduled sync tasks");

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -37,36 +37,31 @@ async fn account(
     account: AccountsResult,
     period: RangeInclusive<NaiveDate>,
 ) -> Result<(), anyhow::Error> {
-    jobs.enqueue(
+    jobs.spawn(
         account_balance(tl.clone(), target_dir.clone(), account.clone())
             .instrument(Span::current()),
-    )
-    .await?;
-    jobs.enqueue(
+    )?;
+    jobs.spawn(
         account_pending(tl.clone(), target_dir.clone(), account.clone())
             .instrument(Span::current()),
-    )
-    .await?;
+    )?;
     for month in months(period) {
-        jobs.enqueue(
+        jobs.spawn(
             account_tx(tl.clone(), target_dir.clone(), account.clone(), month)
                 .instrument(Span::current()),
-        )
-        .await?;
+        )?;
     }
 
     if false {
         // Only available when you've _recently_ authenticated.
-        jobs.enqueue(
+        jobs.spawn(
             account_standing_orders(tl.clone(), target_dir.clone(), account.clone())
                 .instrument(Span::current()),
-        )
-        .await?;
-        jobs.enqueue(
+        )?;
+        jobs.spawn(
             account_direct_debits(tl.clone(), target_dir.clone(), account.clone())
                 .instrument(Span::current()),
-        )
-        .await?;
+        )?;
     }
     Ok(())
 }
@@ -95,18 +90,16 @@ async fn card(
     card: CardsResult,
     period: RangeInclusive<NaiveDate>,
 ) -> Result<(), anyhow::Error> {
-    jobs.enqueue(
+    jobs.spawn(
         card_balance(tl.clone(), target_dir.clone(), card.account_id.clone())
             .instrument(Span::current()),
-    )
-    .await?;
-    jobs.enqueue(
+    )?;
+    jobs.spawn(
         card_pending(tl.clone(), target_dir.clone(), card.account_id.clone())
             .instrument(Span::current()),
-    )
-    .await?;
+    )?;
     for month in months(period) {
-        jobs.enqueue(
+        jobs.spawn(
             card_tx(
                 tl.clone(),
                 target_dir.clone(),
@@ -114,8 +107,7 @@ async fn card(
                 month,
             )
             .instrument(Span::current()),
-        )
-        .await?;
+        )?
     }
     Ok(())
 }


### PR DESCRIPTION
This reverts commit cc10b994bbbc0513b6e77ac0b3e5ccbc32ab045a.

While all of our jobs form a DAG, it's possible for multiple "branch" jobs to be running at the same time, which will compete for the ability to submit jobs to the pool, and thus basically deadlock.